### PR TITLE
fix(state): distinguish zero from missing in per-source adjacent counter fallback

### DIFF
--- a/internal/core/state.go
+++ b/internal/core/state.go
@@ -931,13 +931,13 @@ func (sm *StateManager) emitKeyingUpdateLocked(sourceNodeID int, timestamp time.
 		return
 	}
 
-	// Derive per-source counters (fallback to global if missing)
-	perLinks := sm.perSourceNumLinks[sourceNodeID]
-	perALinks := sm.perSourceNumALinks[sourceNodeID]
-	if perLinks == 0 {
+	// Derive per-source counters (fallback to global if not set for this source)
+	perLinks, linksOk := sm.perSourceNumLinks[sourceNodeID]
+	perALinks, alinksOk := sm.perSourceNumALinks[sourceNodeID]
+	if !linksOk {
 		perLinks = sm.numLinks
 	}
-	if perALinks == 0 {
+	if !alinksOk {
 		perALinks = sm.numALinks
 	}
 	update := SourceNodeKeyingUpdate{
@@ -981,12 +981,12 @@ func (sm *StateManager) GetSourceNodeSnapshot(nodeID int) (SourceNodeKeyingUpdat
 		return SourceNodeKeyingUpdate{}, false
 	}
 
-	perLinks := sm.perSourceNumLinks[nodeID]
-	perALinks := sm.perSourceNumALinks[nodeID]
-	if perLinks == 0 {
+	perLinks, linksOk := sm.perSourceNumLinks[nodeID]
+	perALinks, alinksOk := sm.perSourceNumALinks[nodeID]
+	if !linksOk {
 		perLinks = sm.numLinks
 	}
-	if perALinks == 0 {
+	if !alinksOk {
 		perALinks = sm.numALinks
 	}
 	return SourceNodeKeyingUpdate{


### PR DESCRIPTION
## Summary

Fixes a second half of the multi-node connector bug where nodes 594951 and 594952 showed 10 adjacent nodes (same as 594950) instead of 0.

### Root Cause

`emitKeyingUpdateLocked` and `GetSourceNodeSnapshot` in `state.go` were treating a per-source counter value of `0` as "not set" and falling back to the global counter (`sm.numALinks = 10`). This made it impossible to represent a legitimately zero adjacent-node count — it would always be replaced with the global value.

The first half of the fix (PR #155) correctly routed `RPT_LINKS` to only the matching tracker. But the zero-value fallback bug remained: even when that routing was fixed, nodes with 0 adjacent nodes would display 10 because `perALinks == 0` triggered the fallback.

### Fix

Changed the map lookup to use the Go comma-ok idiom to distinguish:
- **Key absent** → fallback to global counter (correct for "never had any data")
- **Key present with value 0** → emit 0 (correct for "legitimately zero adjacent nodes")

```go
// Before (broken): treated 0 as "missing"
perLinks := sm.perSourceNumLinks[sourceNodeID]
if perLinks == 0 {
    perLinks = sm.numLinks
}

// After (fixed): distinguishes missing from zero
perLinks, linksOk := sm.perSourceNumLinks[sourceNodeID]
if !linksOk {
    perLinks = sm.numLinks
}
```

Same change applied to both `emitKeyingUpdateLocked` and `GetSourceNodeSnapshot`.

## Test Plan

1. Build passes: `go build ./...`
2. Tests pass: `go test ./...`
3. **Manual verification**: After deployment to asl3, hard-refresh and verify:
   - Node 594950: shows 10 adjacent (unchanged)
   - Node 594951: shows 0 adjacent (was incorrectly showing 10)
   - Node 594952: shows 0 adjacent (was incorrectly showing 10)

## Files Changed

- `internal/core/state.go` — 2 code blocks updated (9 insertions, 9 deletions)