### PR TITLE
chore(release): add merge plugin to release-please config

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -12,5 +12,5 @@
       "include-component-in-tag": false
     }
   },
-  "plugins": []
+  "plugins": ["merge"]
 }


### PR DESCRIPTION
## Summary

The Release Please workflow is failing because it can't parse squash-merge commit messages like:

```
Merge pull request #160 from dbehnke/fix/adjacent-nodes-seed-and-clear
```

The `merge` plugin tells release-please to skip parsing individual commits and instead consider the combined diff, avoiding this issue entirely.

**Why this is needed**: All PRs are squash-merged, producing commit messages that don't follow conventional commit format. Release Please's default strategy tries to parse each commit's subject line as a conventional commit, which fails on these merge messages.

## Testing

- `golangci-lint run` — 0 issues  
- `go vet ./...` — clean
- `go test ./...` — all pass

## Note

This is a repeat of the same fix pushed to `fix/shared-server-node-header-filter` branch accidentally — that branch was ahead of main by 1 commit (the state.go fix). This PR only includes the `.release-please-config.json` change.

**Labels**: chore, release-tooling