### PR TITLE
fix(release): remove unsupported merge plugin

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -12,5 +12,5 @@
       "include-component-in-tag": false
     }
   },
-  "plugins": ["merge"]
+  "plugins": []
 }


### PR DESCRIPTION
## Summary

Reverts the `merge` plugin added in #163. The `merge` plugin requires release-please v17.6.0 but the workflow uses v17.3.0.

The squash merge commit format was separately changed to `PR_TITLE` with `BLANK` message, which ensures PR titles (conventional commit format like `fix(state): ...`) are used as commit messages — release-please can parse these correctly.

## Changes

- Remove `"plugins": ["merge"]` from `.release-please-config.json`
- The repository squash settings (`squash_merge_commit_title=PR_TITLE`, `squash_merge_commit_message=BLANK`) are already applied and do not need to change

**Labels**: fix, release-tooling