### PR TITLE
chore(deps): update release-please-action to v5

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run release-please
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         id: release
         with:
           config-file: .release-please-config.json


### PR DESCRIPTION
## Summary

Updates the release-please GitHub Action from v4 to v5. This includes:
- Support for the `merge` plugin (if we want to re-add it later)
- Updated Node.js runtime (avoids the Node 20 deprecation warning)
- Latest release-please CLI features

## Testing

- [x] `golangci-lint run` — 0 issues
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass

**Labels**: chore, dependencies