### PR TITLE
fix(release): use release-please-oss/release-please-action v5

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run release-please
-        uses: googleapis/release-please-action@v5
+        uses: release-please-oss/release-please-action@v5
         id: release
         with:
           config-file: .release-please-config.json


### PR DESCRIPTION
## Summary

The `googleapis/release-please-action@v5` doesn't exist (latest is v4.4.0). Switching to the community-maintained fork `release-please-oss/release-please-action@v5` which does have a v5 release.

## Testing

- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass

**Labels**: fix, release-tooling