### PR TITLE
fix: prevent KE8TFM stuck in 'Ending...' state

### DIFF
--- a/frontend/src/components/SourceNodeCard.vue
+++ b/frontend/src/components/SourceNodeCard.vue
@@ -926,14 +926,14 @@ function formatSeconds(seconds) {
 
 function getStatusClass(node) {
   // Show keyed if transmitting, regardless of PendingUnkey state
-  if (node.PendingUnkey) return 'ending'
   if (node.IsTransmitting) return 'keyed'
+  if (node.PendingUnkey) return 'ending'
   return 'idle'
 }
 
 function getStatusText(node) {
-  if (node.PendingUnkey) return 'Ending...'
   if (node.IsTransmitting) return 'Keyed'
+  if (node.PendingUnkey) return 'Ending...'
   return 'Idle'
 }
 

--- a/internal/core/keying_tracker.go
+++ b/internal/core/keying_tracker.go
@@ -158,6 +158,12 @@ func (kt *KeyingTracker) SyncAdjacentNodes(adjacentNodeIDs []int, keyedMap map[i
 		if keyed, ok := keyedMap[nodeID]; ok {
 			nodeStatus.IsKeyed = keyed
 			nodeStatus.IsTransmitting = keyed
+			// If the node is keyed (actively transmitting), clear any pending unkey state
+			// to prevent getting stuck in an inconsistent PendingUnkey=true state
+			if keyed {
+				nodeStatus.PendingUnkey = false
+				kt.removeFromQueue(nodeID)
+			}
 		}
 		newMap[nodeID] = nodeStatus
 	}

--- a/internal/core/state.go
+++ b/internal/core/state.go
@@ -1097,7 +1097,6 @@ func (sm *StateManager) ApplyCombinedStatus(combined *ami.CombinedNodeStatus) {
 
 		// Update fields from XStat
 		li.IP = conn.IP
-		li.IsKeyed = conn.IsKeyed
 		li.Direction = conn.Direction
 		li.Elapsed = conn.Elapsed
 		li.LinkType = conn.LinkType
@@ -1121,6 +1120,8 @@ func (sm *StateManager) ApplyCombinedStatus(combined *ami.CombinedNodeStatus) {
 			isCurrentlyKeyed = conn.KeyingInfo.IsKeyed
 		}
 		li.UpdateTx(isCurrentlyKeyed, now)
+		// Keep IsKeyed in sync with CurrentTx so the UI shows consistent state
+		li.IsKeyed = li.CurrentTx
 
 		// Enrich with node lookup data (callsign, description, location)
 		if sm.nodeLookup != nil {


### PR DESCRIPTION
Frontend: Prioritize IsTransmitting over PendingUnkey in status display. When a node was actively transmitting but had PendingUnkey=true, the UI showed 'Ending...' forever. Now it correctly shows 'Keyed' when transmitting.

Backend: SyncAdjacentNodes now clears PendingUnkey when node is keyed. The polling sync method overwrote IsTransmitting without clearing PendingUnkey, leaving nodes in an inconsistent state.

Fixes dashboard issue where KE8TFM appeared stuck in 'Ending...' state.